### PR TITLE
Fixing variable type for Laravel 5.3

### DIFF
--- a/src/LarametricsRouteServiceProvider.php
+++ b/src/LarametricsRouteServiceProvider.php
@@ -31,7 +31,7 @@ class LarametricsRouteServiceProvider extends ServiceProvider {
                     //echo 'Terminating: ' . microtime(true);
 
                     $shouldAddRequest = true;
-                    $actions = $routeMatched->route->action;
+                    $actions = $routeMatched->route['action'];
                     if(isset($actions['controller']) && str_contains($actions['controller'], 'Larametrics')) {
                         if(config('larametrics.ignoreLarametricsRequests')) {
                             $shouldAddRequest = false;


### PR DESCRIPTION
The `$routeMatched->route` route parameter is of type array and not object.