### PR TITLE
fix error happening when request has no referer

### DIFF
--- a/src/resources/views/requests/show.blade.php
+++ b/src/resources/views/requests/show.blade.php
@@ -47,7 +47,7 @@
                         </tr>
                         <tr>
                             <td>Referer</td>
-                            <td><strong>{{ $headers['referer'][0] }}</strong></td>
+                            <td><strong>{{ $headers['referer'][0] or '-' }}</strong></td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Hi,

`Undefined index: referer` error happens when you click **View Details** button of a request which has no referer so I put a default value to prevent.