### PR TITLE
Fixed pageTitle expression

### DIFF
--- a/src/resources/views/common/default.blade.php
+++ b/src/resources/views/common/default.blade.php
@@ -12,7 +12,7 @@
             <div class="my-3 my-md-5">
                 <div class="container">
                     <div class="page-header">
-                        <h1 class="page-title">{{ $pageTitle or 'Page Title Goes Here' }}</h1>
+                        <h1 class="page-title">{{ $pageTitle ?: 'Page Title Goes Here' }}</h1>
                         @if(isset($pageSubtitle))
                             <div class="text-muted mb-0 ml-4">{{ $pageSubtitle }}</div>
                         @endif


### PR DESCRIPTION
`$pageTitle or 'Page Title Goes Here'` some times results in a Boolean value instead of the of the default page title.

The image below shows the error, I have now fixed it.

![download](https://user-images.githubusercontent.com/6323063/47700603-19df9900-dc3d-11e8-82ba-cafd9f51a84a.png)
