### PR TITLE
Fix drop larametrics_notifications table name

### DIFF
--- a/src/database/migrations/2018_08_02_000000_create_larametrics_notifications_table.php
+++ b/src/database/migrations/2018_08_02_000000_create_larametrics_notifications_table.php
@@ -31,6 +31,6 @@ class CreateLarametricsNotificationsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('larametrics_logs');
+        Schema::dropIfExists('larametrics_notifications');
     }
 }


### PR DESCRIPTION
The down method used to drop another table, it should be "larametrics_notifications" instead of "larametrics_logs".