### PR TITLE
Changing URI to TEXT type per #15

### DIFF
--- a/src/database/migrations/2018_07_01_000000_create_larametrics_requests_table.php
+++ b/src/database/migrations/2018_07_01_000000_create_larametrics_requests_table.php
@@ -16,7 +16,7 @@ class CreateLarametricsRequestsTable extends Migration
         Schema::create('larametrics_requests', function (Blueprint $table) {
             $table->increments('id');
             $table->string('method');
-            $table->string('uri');
+            $table->text('uri');
             $table->string('ip')->nullable();
             $table->text('headers')->nullable();
             $table->float('start_time', 16, 4)->nullable();


### PR DESCRIPTION
Changing URI from VARCHAR to TEXT per #15 

Max length of URIs can reach 2048 characters. We need a much longer placeholder for them.