### PR TITLE
Adds missing functionality to logs

### DIFF
--- a/src/LarametricsLogServiceProvider.php
+++ b/src/LarametricsLogServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Log\Events\MessageLogged;
 use Aschmelyun\Larametrics\Models\LarametricsLog;
 use Aschmelyun\Larametrics\Models\LarametricsNotification;
 use Aschmelyun\Larametrics\Notifications\LogWritten;
+use Carbon\Carbon;
 
 class LarametricsLogServiceProvider extends ServiceProvider {
 

--- a/src/LarametricsLogServiceProvider.php
+++ b/src/LarametricsLogServiceProvider.php
@@ -20,12 +20,12 @@ class LarametricsLogServiceProvider extends ServiceProvider {
         Event::listen(MessageLogged::class, function(MessageLogged $e) {
             try {
                 
-                if(config('larametrics.logsWatchedExpireDays') !== '0') {
+                if(config('larametrics.logsWatchedExpireDays') !== 0) {
                     $expiredLogs = LarametricsLog::where('created_at', '<', Carbon::now()->subDays(config('larametrics.logsWatchedExpireDays'))->toDateTimeString())
                         ->delete();
                 }
                 
-                if(config('larametrics.logsWatchedExpireAmount') !== '0') {
+                if(config('larametrics.logsWatchedExpireAmount') !== 0) {
                     $expiredLogs = LarametricsLog::orderBy('created_at', 'desc')
                         ->offset(config('larametrics.logsWatchedExpireAmount'))
                         ->limit(config('larametrics.logsWatchedExpireAmount'))

--- a/src/LarametricsLogServiceProvider.php
+++ b/src/LarametricsLogServiceProvider.php
@@ -18,6 +18,21 @@ class LarametricsLogServiceProvider extends ServiceProvider {
     {
         Event::listen(MessageLogged::class, function(MessageLogged $e) {
             try {
+                
+                if(config('larametrics.logsWatchedExpireDays') !== '0') {
+                    $expiredLogs = LarametricsLog::where('created_at', '<', Carbon::now()->subDays(config('larametrics.logsWatchedExpireDays'))->toDateTimeString())
+                        ->delete();
+                }
+                
+                if(config('larametrics.logsWatchedExpireAmount') !== '0') {
+                    $expiredLogs = LarametricsLog::orderBy('created_at', 'desc')
+                        ->offset(config('larametrics.logsWatchedExpireAmount'))
+                        ->limit(config('larametrics.logsWatchedExpireAmount'))
+                        ->pluck('id')
+                        ->toArray();
+                     LarametricsLog::destroy($expiredLogs);
+                }
+                
                 $larametricsLog = LarametricsLog::create([
                     'level' => $e->level,
                     'message' => $e->message,


### PR DESCRIPTION
The larametrics config file specifies `logsWatchedExpireDays` and `logsWatchedExpireAmount` values but they are not defined in the code base. Added the to the log creation process to check before the log is added.