### PR TITLE
Fix issue #30: strlen() expects parameter 1 to be string, array given

### DIFF
--- a/src/resources/views/emails/log-written.blade.php
+++ b/src/resources/views/emails/log-written.blade.php
@@ -69,6 +69,7 @@ background-color: #f6f6f6;
 										{{ $content }}
 									</td>
 								</tr><tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;"><td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+										URL: {{ Request::fullUrl() }}<br><br>
                                         Message:<br>
                                         &nbsp;&nbsp;&bull;&nbsp;<strong style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">{{ $requestInfo['message'] }}</strong>
 									</td>

--- a/src/resources/views/metrics/index.blade.php
+++ b/src/resources/views/metrics/index.blade.php
@@ -107,7 +107,7 @@
                         </thead>
                         <tbody>
                             @foreach($models as $model)
-                                @php 
+                                @php
                                     $methodClass = 'fe-circle text-info';
                                     if($model->method === 'deleted') {
                                         $methodClass = 'fe-minus-circle text-danger';
@@ -125,14 +125,14 @@
                                             $original = json_decode($model->original, true);
                                             $changes = json_decode($model->changes, true);
                                         @endphp
-        
+
                                         @if($changes && count($changes))
                                             @php
                                                 $changeArray = array();
 
                                                 foreach($changes as $column => $change) {
 
-                                                    $changeChars = str_split($change);
+                                                	$changeChars = is_array($change) ? str_split($change['date']) : str_split($change);
                                                     $originalChars = str_split($original[$column]);
                                                     $changeNumbers = array(
                                                         'added' => 0,

--- a/src/resources/views/models/model.blade.php
+++ b/src/resources/views/models/model.blade.php
@@ -20,7 +20,7 @@
                     </thead>
                     <tbody>
                         @foreach($models as $model)
-                            @php 
+                            @php
                                 $methodClass = 'fe-circle text-info';
                                 if($model->method === 'deleted') {
                                     $methodClass = 'fe-minus-circle text-danger';
@@ -38,7 +38,7 @@
                                         $original = json_decode($model->original, true);
                                         $changes = json_decode($model->changes, true);
                                     @endphp
-    
+
                                     @if($model->method === 'created' && count($original))
                                         <pre style="white-space: pre-wrap;line-height:1.5rem">@foreach($original as $column => $data){{ $column }} <span class="text-success">+{{ strlen($data) }}</span><br>@endforeach</pre>
                                     @endif
@@ -53,7 +53,7 @@
 
                                             foreach($changes as $column => $change) {
 
-                                                $changeChars = str_split($change);
+                                                $changeChars = is_array($change) ? str_split($change['date']) : str_split($change);
                                                 $originalChars = str_split($original[$column]);
                                                 $changeNumbers = array(
                                                     'added' => 0,

--- a/src/resources/views/models/show.blade.php
+++ b/src/resources/views/models/show.blade.php
@@ -22,7 +22,7 @@
                             <div class="col-sm-6">
                                 <pre style="white-space:normal;line-height:1.5rem;margin:0;">
                                     @php
-                                        $changeChars = str_split($content);
+                                        $changeChars = is_array($content) ? str_split($content['date']) : str_split($content);
                                         $originalChars = str_split($original[$column]);
                                         foreach($originalChars as $index => $char) {
                                             if(isset($changeChars[$index])) {


### PR DESCRIPTION
I've noticed this bug appears not on all version of Laravel. I got it on Laravel 5.7.12. So I added check if variable is array then str_split element of an array, otherwise do as before