### PR TITLE
Fix: Use Http request to get model name; Fix loops in model detail pa…

### DIFF
--- a/src/Http/Controllers/ModelController.php
+++ b/src/Http/Controllers/ModelController.php
@@ -39,8 +39,9 @@ class ModelController extends Controller
         ]);
     }
 
-    public function show($model)
+    public function show(Request $request)
     {
+        $model = $request->route('model');
         if(is_numeric($model)) {
             $larametricsModel = LarametricsModel::find($model);
 

--- a/src/resources/views/models/model.blade.php
+++ b/src/resources/views/models/model.blade.php
@@ -40,11 +40,23 @@
                                     @endphp
 
                                     @if($model->method === 'created' && count($original))
-                                        <pre style="white-space: pre-wrap;line-height:1.5rem">@foreach($original as $column => $data){{ $column }} <span class="text-success">+{{ strlen($data) }}</span><br>@endforeach</pre>
+                                        <pre style="white-space: pre-wrap;line-height:1.5rem">
+                                            @foreach($original as $column => $data)
+                                                @if (is_string($data))
+                                                    {{ $column }} <span class="text-success">+{{ strlen($data) }}</span><br>
+                                                @endif
+                                            @endforeach
+                                        </pre>
                                     @endif
 
                                     @if($model->method === 'deleted' && count($original))
-                                        <pre style="white-space: pre-wrap;line-height:1.5rem">@foreach($original as $column => $data){{ $column }} <span class="text-danger">-{{ strlen($data) }}</span><br>@endforeach</pre>
+                                        <pre style="white-space: pre-wrap;line-height:1.5rem">
+                                            @foreach($original as $column => $data)
+                                                @if (is_string($data))
+                                                    {{ $column }} <span class="text-danger">-{{ strlen($data) }}</span><br>
+                                                @endif
+                                            @endforeach
+                                        </pre>
                                     @endif
 
                                     @if($changes && count($changes))

--- a/src/resources/views/models/show.blade.php
+++ b/src/resources/views/models/show.blade.php
@@ -80,11 +80,19 @@
                         <div class="row mb-6">
                             <div class="col-sm-12">
                                 <pre style="white-space:normal;line-height:1.5rem;margin:0;">
-                                    @if($model->method === 'created')
-                                        <span class="text-success">{{ $data }}</span>
-                                    @elseif($model->method === 'deleted')
-                                        <span class="text-danger">{{ $data }}</span>
+                                    @if ($model->method === 'created')
+                                        <span class="text-success">
+                                    @elseif ($model->method === 'deleted')
+                                        <span class="text-danger">
                                     @endif
+                                        @if (!is_array($data))
+                                            {{ $data }}
+                                        @else
+                                            @foreach($data as $key => $value)
+                                                {{ $key }} = {{ $value }} <br/>
+                                            @endforeach
+                                        @endif
+                                    </span>
                                 </pre>
                             </div>
                         </div>


### PR DESCRIPTION
I have a URL structure like: `domain.com/en/admin/metrics/models/App+Users`
The old way the `$model` variable contained `en`. It's much safer to use the request with the actual parameter name.

Another issue occurs when `$data` is an array in those two loops in the views.