### PR TITLE
Fix error causing config isn't countable

### DIFF
--- a/resources/views/common/partials/header.blade.php
+++ b/resources/views/common/partials/header.blade.php
@@ -16,7 +16,7 @@
                             <a href="{{ route('larametrics::logs.index') }}" class="nav-link{{ str_contains(Request::route()->getName(), 'larametrics::logs') ? ' active' : '' }}"><i class="fe fe-file-text"></i> Logs</a>
                         </li>
                     @endif
-                    @if(count(config('larametrics.modelsWatched')) || !config('larametrics.hideUnwatchedMenuItems'))
+                    @if(is_countable(config('larametrics.modelsWatched')) && count(config('larametrics.modelsWatched')) || !config('larametrics.hideUnwatchedMenuItems'))
                         <li class="nav-item d-inline-block">
                             <a href="{{ route('larametrics::models.index') }}" class="nav-link{{ str_contains(Request::route()->getName(), 'larametrics::models') ? ' active' : '' }}"><i class="fe fe-database"></i> Models</a>
                         </li>

--- a/resources/views/metrics/index.blade.php
+++ b/resources/views/metrics/index.blade.php
@@ -88,7 +88,7 @@
                 </div>
             </div>
         @endif
-        @if(count(config('larametrics.modelsWatched')) || !config('larametrics.hideUnwatchedMenuItems'))
+        @if(is_countable(config('larametrics.modelsWatched')) && count(config('larametrics.modelsWatched')) || !config('larametrics.hideUnwatchedMenuItems'))
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Latest Model Changes</h3>

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,3 +18,10 @@ if (!function_exists('str_contains')) {
         return false;
     }
 }
+
+if (!function_exists('is_countable')) {
+    function is_countable($countable)
+    {
+        return is_array($countable) || $countable instanceof Countable;
+    }
+}


### PR DESCRIPTION
The configuration causes an error when data from the configuration cannot be calculated.

```
[2020-04-17 18:06:24] local.ERROR: count(): Parameter must be an array or an object that implements Countable (View: /var/www/html/cloud.octopy.io/vendor/aschmelyun/larametrics/resources/views/metrics/index.blade.php) {"exception":"[object] (Facade\\Ignition\\Exceptions\\ViewException(code: 0): count(): Parameter must be an array or an object that implements Countable (View: /var/www/html/cloud.octopy.io/vendor/aschmelyun/larametrics/resources/views/metrics/index.blade.php) at /var/www/html/cloud.octopy.io/vendor/aschmelyun/larametrics/src/../resources/views/metrics/index.blade.php:91)
```